### PR TITLE
feat: implement FilterOverdue function

### DIFF
--- a/go/filteroverduetasks/filteroverduetasks.go
+++ b/go/filteroverduetasks/filteroverduetasks.go
@@ -1,0 +1,33 @@
+package filteroverduetasks
+
+import "time"
+
+// Task represents a unit of work with a due date and completion state.
+// Title: short human readable label.
+// Due: absolute time when the task is expected to be completed.
+// Completed: whether the task has already been finished.
+type Task struct {
+	Title     string
+	Due       time.Time
+	Completed bool
+}
+
+// FilterOverdue returns all tasks whose due date is strictly before the provided
+// 'today' instant and that are not completed. The input slice order is preserved
+// among the returned tasks.
+func FilterOverdue(tasks []Task, today time.Time) []Task {
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	overdue := make([]Task, 0, len(tasks))
+	for _, t := range tasks {
+		if !t.Completed && t.Due.Before(today) {
+			overdue = append(overdue, t)
+		}
+	}
+	if len(overdue) == 0 {
+		return nil
+	}
+	return overdue
+}

--- a/go/filteroverduetasks/filteroverduetasks_test.go
+++ b/go/filteroverduetasks/filteroverduetasks_test.go
@@ -1,0 +1,49 @@
+package filteroverduetasks
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFilterOverdueBasic(t *testing.T) {
+	base := time.Date(2025, 11, 10, 12, 0, 0, 0, time.UTC)
+	tasks := []Task{
+		{Title: "past incomplete", Due: base.Add(-2 * time.Hour), Completed: false},
+		{Title: "future incomplete", Due: base.Add(2 * time.Hour), Completed: false},
+		{Title: "past complete", Due: base.Add(-3 * time.Hour), Completed: true},
+	}
+
+	overdue := FilterOverdue(tasks, base)
+	if len(overdue) != 1 || overdue[0].Title != "past incomplete" {
+		t.Fatalf("expected one overdue task 'past incomplete', got %#v", overdue)
+	}
+}
+
+func TestFilterOverdueEmpty(t *testing.T) {
+	base := time.Now()
+	overdue := FilterOverdue(nil, base)
+	if overdue != nil {
+		t.Fatalf("expected nil for empty input, got %#v", overdue)
+	}
+}
+
+func TestFilterOverdueNone(t *testing.T) {
+	base := time.Date(2025, 11, 10, 12, 0, 0, 0, time.UTC)
+	tasks := []Task{{Title: "future", Due: base.Add(1 * time.Minute), Completed: false}}
+	overdue := FilterOverdue(tasks, base)
+	if overdue != nil {
+		t.Fatalf("expected nil slice, got %#v", overdue)
+	}
+}
+
+func TestFilterOverdueBoundary(t *testing.T) {
+	base := time.Date(2025, 11, 10, 12, 0, 0, 0, time.UTC)
+	tasks := []Task{
+		{Title: "exact boundary", Due: base, Completed: false},
+		{Title: "one ns before", Due: base.Add(-1 * time.Nanosecond), Completed: false},
+	}
+	overdue := FilterOverdue(tasks, base)
+	if len(overdue) != 1 || overdue[0].Title != "one ns before" {
+		t.Fatalf("expected only 'one ns before', got %#v", overdue)
+	}
+}


### PR DESCRIPTION
## Description

Add new package `filteroverduetasks` with Task struct and `FilterOverdue` function to return overdue, incomplete tasks while preserving order.


## Related Issue

[Filter Overdue Tasks](https://github.com/tr1sm0s1n/lgtm-workshop/issues/20)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `filteroverduetasks.go`
- Implemented Task struct (Title, Due, Completed)
- Implemented [FilterOverdue] with strict Due.Before(today) logic

## Testing

```
cd go
go test ./...
```

Added unit tests (if present in branch) verifying:

- Overdue filtering
- Excludes completed tasks
- Boundary: due exactly at [today] not overdue
- Empty / no overdue returns nil

## Screenshots
NA

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Current behavior returns nil when no overdue tasks; can switch to empty slice if preferred.